### PR TITLE
add mannequins W/ info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .byebug_history
+.idea/

--- a/data/mannequins.css
+++ b/data/mannequins.css
@@ -1,0 +1,131 @@
+.mannequins p {
+  line-height: 1.3;
+}
+.mannequins hr {
+  height: 1px;
+  border: 0;
+  background: #ddd;
+  margin: 20px 0;
+  line-height: 1px;
+}
+.mannequins blockquote {
+  margin-left: 20px;
+  border-left: 2px solid #eee;
+  padding-left: 10px;
+  font-size: 90%;
+  line-height: 1.3;
+}
+
+.mannequins ul {
+  line-height: 1.5;
+  list-style: square;
+  padding: 0 0 0 2.5ex;
+}
+
+.mannequins ol {
+  line-height: 1.5;
+  padding: 0 0 0 3ex;
+}
+
+.mannequins ins {
+  text-decoration: none;
+  padding: 1px 3px;
+  border: 1px solid #999;
+  border-radius: 5px;
+  line-height: 1;
+  font-size: 85%;
+}
+
+.mannequins kbd {
+  font: inherit;
+  font-style: italic;
+  background: #e7e7e7;
+  padding: 1px 4px;
+  border-radius: 4px;
+}
+.mannequins hr + h3 {
+  margin-top:0 !important;
+}
+.mannequins h3:not(:first-child) {
+  margin-top: 2em;
+}
+
+.mannequins p.wleds {
+  line-height: 0.9;
+  margin:0;
+  padding: 0;
+}
+
+.mannequins span.wled {
+  display: inline-block;
+  height: 0.8ex;
+  width: 0.8ex;
+  border-radius: 50%;
+  margin-left: 2px;
+  margin-right: 2px;
+  background: #555;
+  border: 1px solid transparent;
+  vertical-align: middle;
+}
+.mannequins li span.wled {
+  height: 0.6ex;
+  width: 0.6ex;
+}
+
+.mannequins span.wled-orange {
+  background: #fb0;
+}
+
+.mannequins span.wled-white {
+  background: #fff;
+  border: 1px solid #cfcfcf;
+}
+
+@keyframes pulsing-orange {
+  0% { background: #333; }
+  20% { background: #fb0; }
+  80% { background: #fb0; }
+  100% { background: #333; }
+}
+
+@keyframes pulsing-white {
+  0% { background: #333; }
+  20% { background: white; }
+  80% { background: white; }
+  100% { background: #333; }
+}
+
+@keyframes pulsing-orange-alt {
+  0% { background: #333; }
+  20% { background: #cb9500; }
+  100% { background: #fb0; }
+}
+
+@keyframes pulsing-white-alt {
+  0% { background: #fff; }
+  80% { background: #fff; }
+  100% { background: #ccc; }
+}
+
+@keyframes blinking-white {
+  0% { background: #333; }
+  69% { background: #333; }
+  70% { background: white; }
+  100% { background: white; }
+}
+
+@keyframes blinking-orange {
+  0% { background: #333; }
+  69% { background: #333; }
+  70% { background: #fb0; }
+  100% { background: #fb0; }
+}
+
+.mannequins span.wled-white.wled-pulse { animation: pulsing-white 0.7s linear infinite; }
+.mannequins span.wled-orange.wled-pulse { animation: pulsing-orange 0.7s linear infinite; }
+.mannequins span.wled-white.wled-pulse-alt { animation: pulsing-white-alt 1.2s 0s linear infinite; }
+.mannequins span.wled-orange.wled-pulse-alt { animation: pulsing-orange-alt 1.2s 0s linear infinite; }
+.mannequins span.wled-white.wled-blink { animation: blinking-white 0.7s linear infinite; }
+.mannequins span.wled-orange.wled-blink { animation: blinking-orange 0.7s linear infinite; }
+.mannequins span.wled-white.wled-blink-alt { animation: blinking-white 0.7s 0.25s linear infinite; }
+.mannequins span.wled-orange.wled-blink-alt { animation: blinking-orange 0.7s 0.25s linear infinite; }

--- a/data/mannequins_w/module.xml
+++ b/data/mannequins_w/module.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<module>
+  <sections>
+    <section name="General" modelist="false">
+      <page name="Info" content="w_info.html"/>
+      <page name="System" content="w_system.html"/>
+    </section>
+    <section name="Modes" modelist="true">
+      <page name="Nav" content="w_nav.html"/>
+      <page name="Live" content="w_live.html"/>
+      <page name="Cue" content="w_cue.html"/>
+      <page name="Global" content="w_global.html"/>
+    </section>
+  </sections>
+</module>

--- a/data/mannequins_w/w_cue.html
+++ b/data/mannequins_w/w_cue.html
@@ -1,0 +1,96 @@
+<html class="no-js">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content="">
+  <meta charset="utf-8">
+
+  <title>W/ Cue Mode</title>
+  <meta name="description" content="">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta http-equiv="cleartype" content="on">
+  <link rel="stylesheet" href="../common.css" type="text/css">
+  <link rel="stylesheet" href="../mannequins.css" type="text/css">
+</head>
+
+<body>
+  <div class="centered">
+    <div class="content mannequins">
+      <h2>Cue</h2>
+
+      <p class="wleds">
+        <span class="wled"></span>
+        <span class="wled wled-white"></span>
+      </p>
+
+      <p>
+        Sampler behaviour and access to editing cues via playhead / cursor.
+      </p>
+
+      <ul>
+        <li>Enter from NAV: <kbd>loop</kbd>+<kbd>record</kbd></li>
+        <li>Exit to NAV: <kbd>loop</kbd></li>
+      </ul>
+
+      <h3>Cursor Navigation</h3>
+      <ul>
+        <li>hold <kbd>play</kbd> to audition. release returns.</li>
+        <li>hold <kbd>↑</kbd> to move cursor forward</li>
+        <li>hold <kbd>↓</kbd> to move cursor back</li>
+      </ul>
+
+      <ul>
+        <li><kbd>loop</kbd>+<kbd>↑</kbd> cursor to next cue</li>
+        <li><kbd>loop</kbd>+<kbd>↓</kbd> cursor to previous cue</li>
+      </ul>
+
+      <hr />
+
+      <h3>Sampler</h3>
+      <ul>
+        <li>
+          <ins>THIS</ins> = gate<br />
+          <small>
+            trigger &gt;15msec play and loop <br />
+            trigger &lt;15msec play without loop <br />
+            mix in CV to select cue: -1V prev, +1V next
+          </small>
+        </li>
+        <li><ins>THAT</ins> = 1V/oct pitch</li>
+      </ul>
+
+      <hr />
+
+      <h3>Cue Editing</h3>
+
+      <p>Disconnect <ins>THIS</ins> and <ins>THAT</ins>.</p>
+      <p>When the playhead/cursor is exactly at a cue point, the orange LED above
+        <kbd style="background: none">record</kbd> lights up.
+      </p>
+      <p>With the LEDs above <kbd style="background: none">record</kbd>:</p>
+      <ul style="list-style: none; padding: 0">
+        <li>
+          <span class="wled"></span>
+          <span class="wled wled-white"></span>
+
+          <kbd>loop</kbd>+<kbd>record</kbd> to add a new cue
+        </li>
+        <li>
+          <span class="wled"></span>
+          <span class="wled wled-white"></span>
+
+          <kbd>record</kbd> to relocate previous cue
+        </li>
+        <li>
+          <span class="wled wled-orange"></span>
+          <span class="wled"></span>
+
+          <kbd>record</kbd> to delete cue
+        </li>
+      </ul>
+
+    </div>
+  </div>
+</body>
+</html>

--- a/data/mannequins_w/w_global.html
+++ b/data/mannequins_w/w_global.html
@@ -1,0 +1,61 @@
+<html class="no-js">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content="">
+  <meta charset="utf-8">
+
+  <title>W/ Global Mode</title>
+  <meta name="description" content="">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta http-equiv="cleartype" content="on">
+  <link rel="stylesheet" href="../common.css" type="text/css">
+  <link rel="stylesheet" href="../mannequins.css" type="text/css">
+</head>
+
+<body>
+  <div class="centered">
+    <div class="content mannequins">
+      <h2>Global</h2>
+      <p class="wleds">
+        <span class="wled wled-orange wled-pulse"></span>
+        <span class="wled wled-white wled-pulse"></span>
+      </p>
+
+      <p>Hold <kbd>record</kbd> in any mode to enter.</p>
+      <p><kbd>↑</kbd> to exit.</p>
+
+      <h3>Select tape</h3>
+      <ol>
+        <li>press <kbd>loop</kbd> to enter selection
+        <span class="wled wled-orange wled-blink"></span>
+        <span class="wled wled-white wled-blink-alt"></span>
+        </li>
+        <li>select tape with <kbd>loop</kbd>, <kbd>play</kbd>, <kbd>record</kbd></li>
+        <li><kbd>↓</kbd> to confirm and exit to NAV</li>
+      </ol>
+      <p>
+        <small>The currently active tape is dimly lit.</small>
+      </p>
+
+
+      <h3>Clear all cues</h3>
+      <ol>
+        <li>hold <kbd>loop</kbd> to select
+          <span class="wled wled-orange"></span>
+          <span class="wled wled-white"></span>
+
+        </li>
+        <li>press <kbd>record</kbd> to confirm, exit to NAV</li>
+      </ol>
+
+      <h3>Input monitoring</h3>
+      <p>
+        <kbd>record</kbd> to toggle <ins>IN</ins>→<ins>OUT</ins> routing
+      </p>
+
+    </div>
+  </div>
+</body>
+</html>

--- a/data/mannequins_w/w_info.html
+++ b/data/mannequins_w/w_info.html
@@ -1,0 +1,31 @@
+<html class="no-js">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content="">
+  <meta charset="utf-8">
+  <title>Mannequins W/</title>
+  <meta name="description" content="">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta http-equiv="cleartype" content="on">
+  <link rel="stylesheet" href="../common.css" type="text/css">
+  <link rel="stylesheet" href="../mannequins.css" type="text/css">
+</head>
+
+<body>
+  <div class="centered">
+    <div class="content mannequins">
+      <h2>W/</h2>
+      <p>Programmable looper by Whimsical Raps.</p>
+      <blockquote>
+        &quot;Considered as a traditional tape system, W/'s sounds can be played forward and back / at fixed speeds / with continuous through-zero momentum.
+        These playings-back are of voices recorded with IN, layered sound upon sounds.&quot;
+      </blockquote>
+      <h3>Links</h3>
+      <a class="button" href="https://www.whimsicalraps.com/products/wslash">W/ product page</a><br>
+      <a class="button" href="https://www.whimsicalraps.com/pages/w-latest-version">Firmware changelog</a><br>
+    </div>
+  </div>
+</body>
+</html>

--- a/data/mannequins_w/w_live.html
+++ b/data/mannequins_w/w_live.html
@@ -1,0 +1,89 @@
+<html class="no-js">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content="">
+  <meta charset="utf-8">
+
+  <title>W/ Kuve Mode</title>
+  <meta name="description" content="">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta http-equiv="cleartype" content="on">
+  <link rel="stylesheet" href="../common.css" type="text/css">
+  <link rel="stylesheet" href="../mannequins.css" type="text/css">
+</head>
+
+<body>
+  <div class="centered">
+    <div class="content mannequins">
+      <h2>Live</h2>
+
+      <p class="wleds">
+        <span class="wled wled-orange wled-pulse-alt"></span>
+        <span class="wled wled-white wled-pulse-alt"></span>
+      </p>
+
+      <p>
+        from NAV, press <kbd>play</kbd> or <kbd>↓</kbd>+<kbd>play</kbd>.<br />
+        The tape plays to <ins>OUT</ins>.<br />
+        <ins>IN</ins> is mixed if enabled (default: on).
+      </p>
+
+
+      <h3>While playing</h3>
+
+      <p><kbd>play</kbd> to stop and exit to NAV.</p>
+
+      <ul>
+        <li><kbd>play</kbd>+<kbd>↑</kbd> double speed</li>
+        <li><kbd>play</kbd>+<kbd>↓</kbd> halve speed</li>
+      </ul>
+
+      <ul>
+        <li><kbd>loop</kbd>+<kbd>↑</kbd> next cue</li>
+        <li><kbd>loop</kbd>+<kbd>↓</kbd> previous cue</li>
+      </ul>
+
+      <ul>
+        <li><kbd>↑</kbd> add a cue (write to tape)</li>
+        <li><kbd>↓</kbd> add a cue and loop</li>
+      </ul>
+
+      <ul>
+        <li><kbd>loop</kbd> toggle looping</li>
+        <li><kbd>record</kbd> toggle recording from <ins>IN</ins></li>
+        <li><kbd>loop</kbd>+<kbd>record</kbd> add cue and record</li>
+        <li><kbd>record</kbd>+<kbd>↓</kbd> - toggle overdub/overwrite</li>
+      </ul>
+
+      <h3>CV</h3>
+      <p>in Dub mode (default)</p>
+      <ul>
+        <li><ins>THIS</ins> - trigger recording on/off</li>
+        <li>
+          <ins>THAT</ins> - (record) level ratio<br />
+          <small>
+            0V overdub<br />
+            -5V overwrite<br />
+            +5V previous material
+          </small>
+        </li>
+      </ul>
+
+      <hr />
+      <h4>Additional CV modes</h4>
+      <p>
+        Starting with firmware 1.2, <ins>THIS</ins> and <ins>THAT</ins> can be reconfigured in LIVE:
+      </p>
+      <ul>
+        <li>for cue &amp; speed control (like NAV)</li>
+        <li>as sampler controls (like CUE)</li>
+        <li>to record CV to the tape</li>
+        <li>output loop position and cue trigger</li>
+      </ul>
+      <p>See the firmware docs for setup details.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/data/mannequins_w/w_nav.html
+++ b/data/mannequins_w/w_nav.html
@@ -1,0 +1,66 @@
+<html class="no-js">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content="">
+  <meta charset="utf-8">
+
+  <title>W/ Nav Mode</title>
+  <meta name="description" content="">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta http-equiv="cleartype" content="on">
+  <link rel="stylesheet" href="../common.css" type="text/css">
+  <link rel="stylesheet" href="../mannequins.css" type="text/css">
+</head>
+
+<body>
+  <div class="centered">
+    <div class="content mannequins">
+      <h2>Nav</h2>
+
+      <p class="wleds">
+        <span class="wled wled-orange"></span>
+        <span class="wled"></span>
+      </p>
+
+      <ul>
+        <li><kbd>play</kbd> to play forward or stop</li>
+        <li><kbd>↓</kbd>+<kbd>play</kbd> to play backwards</li>
+      </ul>
+
+      <ul>
+        <li>hold <kbd>↑</kbd> to seek forward</li>
+        <li>hold <kbd>↓</kbd> to rewind</li>
+      </ul>
+
+      <ul>
+        <li><kbd>loop</kbd> to loop at cue points <br /><small>n/a if playhead isn't between cues</small></li>
+      </ul>
+
+      <h3>Switch modes</h3>
+      <ul>
+        <li><kbd>play</kbd> → LIVE</li>
+        <li><kbd>loop</kbd>+<kbd>record</kbd> → CUE</li>
+        <li>hold <kbd>record</kbd> → GLOBAL</li>
+      </ul>
+
+      <h3>CV Playback in Nav</h3>
+      <ul>
+        <li>
+          <ins>THAT</ins> speed, direction (-5V .. +5V)<br />
+          <small>
+            Negative voltage plays backwards.
+          </small>
+        </li>
+        <li>
+          <ins>THIS</ins> next cue (-5V .. +5V)<br />
+          <small>All available tape cues are assigned evenly across the control's CV range.</small>
+        </li>
+      </ul>
+
+
+    </div>
+  </div>
+</body>
+</html>

--- a/data/mannequins_w/w_system.html
+++ b/data/mannequins_w/w_system.html
@@ -1,0 +1,50 @@
+<html class="no-js">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content="">
+  <meta charset="utf-8">
+  <title>W/ System</title>
+  <meta name="description" content="">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta http-equiv="cleartype" content="on">
+  <link rel="stylesheet" href="../common.css" type="text/css">
+  <link rel="stylesheet" href="../mannequins.css" type="text/css">
+</head>
+
+<body>
+  <div class="centered">
+    <div class="content mannequins">
+      <h2>System</h2>
+      <p>
+        These options are available on boot:
+      </p>
+
+      <h3>Izzy (tutorial)</h3>
+      <p>
+        Hold <kbd>loop</kbd>+<kbd>record</kbd> while powering-on.
+      </p>
+
+      <h3>Clear tape</h3>
+      <ol>
+        <li>Hold <kbd>record</kbd>+<kbd>↓</kbd> while powering-on</li>
+        <li>Release <kbd>record</kbd> and <kbd>↓</kbd>.<br />
+          Orange LED above <kbd>play</kbd> pulses slowly
+        </li>
+        <li>Press <kbd>play</kbd>, <kbd>record</kbd>, <kbd>loop</kbd></li>
+      </ol>
+
+      <h3>Updating the firmware</h3>
+      <ol>
+        <li>Hold <kbd>record</kbd> while powering-on</li>
+        <li>Play firmware audio file into <ins>IN</ins></li>
+      </ol>
+
+      <a class="button" href="https://www.whimsicalraps.com/pages/w-firmware-update">Firmware update procedure</a><br>
+
+
+    </div>
+  </div>
+</body>
+</html>

--- a/data/modules.xml
+++ b/data/modules.xml
@@ -31,5 +31,6 @@
   </manufacturer>
   <manufacturer name="Whimsical Raps">
     <module name="Just Friends" id="just_friends" index="just_friends/module.xml" />
+    <module name="W/" id="mannequins_w" index="mannequins_w/module.xml"/>
   </manufacturer>
 </modules>


### PR DESCRIPTION
fix #37 - first pass W/

covers:
 - nav
 - live
 - cue
 - global
 - system / boot

I wasn't able to get the whole project to run on my system, here are a couple of sample screens anyway.

<img width="340" alt="Screen Shot 2019-06-23 at 03 16 58" src="https://user-images.githubusercontent.com/14101296/59970728-675e9c80-9565-11e9-8c40-54242754cd25.png">

<img width="380" alt="Screen Shot 2019-06-23 at 03 14 24" src="https://user-images.githubusercontent.com/14101296/59970709-10f15e00-9565-11e9-8cfe-22375185f691.png">
