### PR TITLE
Added missing mode for Pico DSP and fixed small build issues

### DIFF
--- a/data/endorphines/squawk_dirty/module.xml
+++ b/data/endorphines/squawk_dirty/module.xml
@@ -2,7 +2,7 @@
 <module>
   <sections>
     <section name="Cheat Sheet" modelist="false">
-      <page name="Cheat Sheet for things you might forget" content="cheat-sheet.html"/>
+      <page name="Cheat Sheet for things you might forget" content="cheat_sheet.html"/>
     </section>
     <section name="Squawk Dirty To Me Manual" modelist="false">
       <page name="Info" content="info.html"/>

--- a/data/pico_dsp/erica.css
+++ b/data/pico_dsp/erica.css
@@ -1,3 +1,6 @@
+.erica-white {
+  background-color: #FFFFFF;
+}
 .erica-black {
   background-color: #000000;
 }

--- a/data/pico_dsp/modes.html
+++ b/data/pico_dsp/modes.html
@@ -31,36 +31,42 @@
           <td class="centered">Feedback</td>
         </tr>
         <tr>
+          <td><div class="led erica-white"></div></td>
+          <td class="centered">Pitch Shift Delay</td>
+          <td class="centered">Pitch</td>
+          <td class="centered">Delay Time</td>
+        </tr>
+        <tr class="highlighted-row">
           <td><div class="led erica-yellow"></div></td>
           <td class="centered">Stereo Delay</td>
           <td class="centered">Delay Time</td>
           <td class="centered">Feedback</td>
         </tr>
-        <tr class="highlighted-row">
+        <tr>
           <td><div class="led erica-green"></div></td>
           <td class="centered">Granular Delay</td>
           <td class="centered">Feedback (Max setting freezes the loop)</td>
           <td class="centered">Delay Time</td>
         </tr>
-        <tr>
+        <tr class="highlighted-row">
           <td><div class="led erica-light-blue"></div></td>
           <td class="centered">Reverb</td>
           <td class="centered">Reverb Time</td>
           <td class="centered">Tone</td>
         </tr>
-        <tr class="highlighted-row">
+        <tr>
           <td><div class="led erica-dark-blue"></div></td>
           <td class="centered">Saturated Reverb</td>
           <td class="centered">Tone</td>
           <td class="centered">Reverb Time</td>
         </tr>
-        <tr>
+        <tr class="highlighted-row">
           <td><div class="led erica-pink"></div></td>
           <td class="centered">Leslie Speaker</td>
           <td class="centered">Rotation Speed</td>
           <td class="centered">High-Pass Filter</td>
         </tr>
-        <tr class="highlighted-row">
+        <tr>
           <td><div class="led erica-red"></div></td>
           <td class="centered">Overdrive/Bitcrush</td>
           <td class="centered">Overdrive</td>

--- a/tools/render_web_data.rb
+++ b/tools/render_web_data.rb
@@ -119,7 +119,7 @@ end
 modules.each do |m|
   dir = "web/modules/#{File.dirname(m.index)}"
   begin
-    FileUtils.mkdir(dir)
+    FileUtils.mkdir_p(dir)
   rescue Errno::EEXIST
   end
   if File.exist?(m.images_dir)


### PR DESCRIPTION
1. Added missing pitch shift delay more for Pico DSP
2. Fixed a type that was causing test.sh to fail on file not found
3. Using mkdir_p in render_web_data.rb since endorphines has subdirectories and fails on a clean build.