### PR TITLE
Pico dsp xodes mod

### DIFF
--- a/data/modules.xml
+++ b/data/modules.xml
@@ -13,6 +13,7 @@
   <manufacturer name="Erica Synths">
     <module name="Black Hole DSP 2" id="black_hole_dsp_2" index="black_hole_dsp_2/module.xml"/>
     <module name="Pico DSP" id="pico_dsp" index="pico_dsp/module.xml"/>
+    <module name="Pico DSP (Xodes Mod)" id="pico_dsp_xodes" index="pico_dsp_xodes/module.xml"/>
     <module name="Pico Logic" id="pico_logic" index="pico_logic/module.xml"/>
     <module name="Pico Seq" id="pico_seq" index="pico_seq/module.xml"/>
     <module name="Pico Voice" id="pico_voice" index="pico_voice/module.xml"/>

--- a/data/pico_dsp_xodes/erica_xodes.css
+++ b/data/pico_dsp_xodes/erica_xodes.css
@@ -1,0 +1,64 @@
+.erica-black {
+  background-color: #000000;
+}
+.erica-white {
+  background-color: #FFFFFF;
+}
+.erica-red {
+  background-color: #B9242B;
+}
+.erica-green {
+  background-color: #399945;
+}
+.erica-dark-blue {
+  background-color: #2A316A;
+}
+.erica-yellow {
+  background-color: #FCEC24;
+}
+.erica-light-blue {
+  background-color: #2C8FC1;
+}
+.erica-orange {
+  background-color: #D8552B;
+}
+.erica-pink {
+  background-color: #E0719F;
+}
+
+.blinking::after {
+  display: block;
+  content: "";
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+  background-color: white;
+  animation: blinking 0.8s infinite;
+}
+
+@keyframes blinking {
+  0% {opacity: 0}
+  49% {opacity: 0}
+  50% {opacity: 1}
+  100% {opacity: 1}
+}
+
+table {
+  border-collapse: collapse;
+}
+
+table tr {
+  height: 46px;
+}
+
+.highlighted-row {
+  background-color: #e3e3e3;
+  color: #000000;
+}
+
+@media (prefers-color-scheme: dark) {
+  .highlighted-row {
+    background-color: #303030;
+    color: #ffffff;
+  }
+}

--- a/data/pico_dsp_xodes/halls_of_valhalla.html
+++ b/data/pico_dsp_xodes/halls_of_valhalla.html
@@ -1,0 +1,92 @@
+<html class="no-js">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content="HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 16.1), see www.w3.org">
+  <meta charset="utf-8">
+
+  <title></title>
+  <meta name="description" content="">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta http-equiv="cleartype" content="on">
+  <link rel="stylesheet" href="../common.css" type="text/css">
+  <link rel="stylesheet" href="erica_xodes.css" type="text/css">
+</head>
+<body>
+  <div class="centered">
+	<div class="content">
+	  <table class="parameters">
+		<tr>
+		  <th class="centered">LED</th>
+		  <th class="centered">Effect</th>
+		  <th class="centered">Wet/Dry</th>
+		  <th class="centered">Par 1</th>
+		  <th class="centered">Par 2</th>
+		</tr>
+		<tr class="highlighted-row">
+		  <td><div class="led erica-black"></div></td>
+		  <td class="centered">1-Room</td>
+		  <td class="centered">Decay</td>
+		  <td class="centered">Tone</td>
+		  <td class="centered">Chorus</td>
+		</tr>
+		<tr>
+		  <td><div class="led erica-white"></div></td>
+		  <td class="centered">8-Ginnungagap</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Pitch</td>
+		</tr>
+		<tr class="highlighted-row">
+		  <td><div class="led erica-yellow"></div></td>
+		  <td class="centered">6-Nilfheim</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+		<tr>
+		  <td><div class="led erica-green"></div></td>
+		  <td class="centered">2-Chamber</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+		<tr class="highlighted-row">
+		  <td><div class="led erica-light-blue"></div></td>
+		  <td class="centered">4-EnsembleVerb</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+		<tr>
+		  <td><div class="led erica-dark-blue"></div></td>
+		  <td class="centered">3-Plate</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+		<tr class="highlighted-row">
+		  <td><div class="led erica-pink"></div></td>
+		  <td class="centered">7-Asgard</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Pitch</td>
+		</tr>
+		<tr>
+		  <td><div class="led erica-red"></div></td>
+		  <td class="centered">5-Cathedral</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+	  </table>
+	  <h3>Notes</h3>
+	  <p>The algorithm order is different from the original order, numbers indicate the original order in increasing size of reverb space. Decay: the first half of the knob travel affects normal decays, beyond that are much larger spaces. Tone: dampens the reverb. Chorus: adds modulation and lushness™</p>
+	  <h3>Links</h3>
+<a class="button" href="https://www.ericasynths.lv/media/Pico_DSP_Manual.pdf">Pico DSP Manual</a><br>
+		<a class="button" href="https://www.xodes.net/product/bci-2hp-eurorack-zdsp-algorithm-card-adapter">Xodes BCI</a></br>
+	</div>
+  </div>
+</body>
+</html>

--- a/data/pico_dsp_xodes/info.html
+++ b/data/pico_dsp_xodes/info.html
@@ -1,0 +1,30 @@
+<html class="no-js">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content="HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 16.1), see www.w3.org">
+  <meta charset="utf-8">
+
+  <title></title>
+  <meta name="description" content="">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta http-equiv="cleartype" content="on">
+  <link rel="stylesheet" href="../common.css" type="text/css">
+</head>
+
+<body>
+  <div class="centered">
+    <div class="content">
+      <h3>Pico DSP (Xodes Mod)</h3>
+      <p>Pico DSP is a small (3HP) digital effects module by Erica Synths. It is considered the little brother to the Erica Synths Black Hole module.</p>
+      <p>This mod allows the Pico DSP module to use effects cards from Tiptop's Z-DSP module.  When using this mod the parameters and the order of the effects on the card will change.  The mod can either be made as a backpack which sits underneath the Pico DSP module or as a sidecar which is accessible from the top.</p>
+      <p>The module has a mono audio input, and stereo outputs.</p>
+      <p>There is a button in the middle of the module that changes between the eight different effects, and an LED that displays the current effect.</p>
+      <h3>Links</h3>
+      <a class="button" href="https://www.ericasynths.lv/media/Pico_DSP_Manual.pdf">Pico DSP Manual</a><br>
+      <a class="button" href="https://www.xodes.net/product/bci-2hp-eurorack-zdsp-algorithm-card-adapter">Xodes BCI</a></br>
+    </div>
+  </div>
+</body>
+</html>

--- a/data/pico_dsp_xodes/modes.html
+++ b/data/pico_dsp_xodes/modes.html
@@ -1,0 +1,86 @@
+<html class="no-js">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="generator" content="HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 16.1), see www.w3.org">
+  <meta charset="utf-8">
+
+  <title></title>
+  <meta name="description" content="">
+  <meta name="HandheldFriendly" content="True">
+  <meta name="MobileOptimized" content="320">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta http-equiv="cleartype" content="on">
+  <link rel="stylesheet" href="../common.css" type="text/css">
+  <link rel="stylesheet" href="erica_xodes.css" type="text/css">
+</head>
+
+<body>
+  <div class="centered">
+    <div class="content">
+      <h3>Parameter Map</h3>
+      <table class="parameters">
+        <tr>
+          <th class="centered"></th>
+          <th class="centered">Pico Control</th>
+          <th class="centered">Algorithm Parameter</th>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-black"></div></td>
+          <td class="centered">Par1</td>
+          <td class="centered">Parameter 2</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-black"></div></td>
+          <td class="centered">Par2</td>
+          <td class="centered">Parameter 3</td>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-black"></div></td>
+          <td class="centered">Dry/Wet</td>
+          <td class="centered">Parameter 1</td>
+        </tr>
+      </table>
+      
+      <h3>Algorithm Ordering</h3>
+      <table class="parameters">
+        <tr>
+          <th class="centered">LED</th>
+          <th class="centered">Algorithm</th>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-black"></div></td>
+          <td class="centered">Algorithm #1</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-white"></div></td>
+          <td class="centered">Algorithm #8</td>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-yellow"></div></td>
+          <td class="centered">Algorithm #6</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-green"></div></td>
+          <td class="centered">Algorithm #2</td>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-light-blue"></div></td>
+          <td class="centered">Algorithm #4</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-dark-blue"></div></td>
+          <td class="centered">Algorithm #3</td>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-pink"></div></td>
+          <td class="centered">Algorithm #7</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-red"></div></td>
+          <td class="centered">Algorithm #5</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</body>
+</html>

--- a/data/pico_dsp_xodes/module.xml
+++ b/data/pico_dsp_xodes/module.xml
@@ -6,6 +6,8 @@
     </section>
     <section name="Modes" modelist="false">
       <page name="Modes" content="modes.html"/>
+    </section>
+    <section name="Specific Cards" modelist="false">
       <page name="Halls of Valhalla" content="halls_of_valhalla.html"/>
     </section>
   </sections>

--- a/data/pico_dsp_xodes/module.xml
+++ b/data/pico_dsp_xodes/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<module>
+  <sections>
+  	<section name="General" modelist="false">
+      <page name="Info" content="info.html"/>
+    </section>
+    <section name="Modes" modelist="false">
+      <page name="Modes" content="modes.html"/>
+      <page name="Halls of Valhalla" content="halls_of_valhalla.html"/>
+    </section>
+  </sections>
+</module>

--- a/web/modules/pico_dsp_xodes/index.html
+++ b/web/modules/pico_dsp_xodes/index.html
@@ -1,0 +1,584 @@
+---
+layout: page
+title: Pico DSP (Xodes Mod)
+manufacturer: Erica Synths
+---
+<style>.erica-black {
+  background-color: #000000;
+}
+.erica-white {
+  background-color: #FFFFFF;
+}
+.erica-red {
+  background-color: #B9242B;
+}
+.erica-green {
+  background-color: #399945;
+}
+.erica-dark-blue {
+  background-color: #2A316A;
+}
+.erica-yellow {
+  background-color: #FCEC24;
+}
+.erica-light-blue {
+  background-color: #2C8FC1;
+}
+.erica-orange {
+  background-color: #D8552B;
+}
+.erica-pink {
+  background-color: #E0719F;
+}
+
+.blinking::after {
+  display: block;
+  content: "";
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+  background-color: white;
+  animation: blinking 0.8s infinite;
+}
+
+@keyframes blinking {
+  0% {opacity: 0}
+  49% {opacity: 0}
+  50% {opacity: 1}
+  100% {opacity: 1}
+}
+
+table {
+  border-collapse: collapse;
+}
+
+table tr {
+  height: 46px;
+}
+
+.highlighted-row {
+  background-color: #e3e3e3;
+  color: #000000;
+}
+
+@media (prefers-color-scheme: dark) {
+  .highlighted-row {
+    background-color: #303030;
+    color: #ffffff;
+  }
+}
+body {
+  font-family: -apple-system, sans-serif;
+}
+
+th {
+  text-align: left;
+}
+
+td {
+  text-align: left;
+  vertical-align: middle;
+  padding: 2px;
+}
+
+h3 {
+  text-align: left;
+}
+
+table {
+  width: 100%;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+@media screen and (prefers-color-scheme: dark) {
+  body {
+    background: #1d1f21;
+    color: #dfdfe0;
+  }
+
+  h1, h2, h3 {
+    color: #ffffff;
+  }
+}
+
+.orange {
+  background-color: #ff9e20;
+}
+
+.green {
+  background-color: #00ee00;
+}
+
+.red {
+  background-color: #f41252;
+}
+
+.blue {
+  background-color: #00928f;
+}
+
+.white {
+  background-color: #ffffff;
+}
+
+.black {
+  background-color: #000000;
+}
+
+.darkgray {
+  background-color: #d5d5d5;
+}
+
+.flashing-green {
+  border: 0px;
+  background-color: #00ee00;
+  box-shadow: 0 0 10px #00ee00, inset 0 0 10px #00ee00;
+}
+
+.flashing-orange {
+  border: 0px;
+  background-color: #ff9e20;
+  box-shadow: 0 0 10px #ff9e20, inset 0 0 10px #ff9e20;
+}
+
+.flashing-red {
+  border: 0px;
+  background-color: #f41252;
+  box-shadow: 0 0 10px #f41252, inset 0 0 10px #f41252;
+}
+
+.flashing-white {
+  border: 0px;
+  background-color: #ffffff;
+  box-shadow: 0 0 10px #ffffff, inset 0 0 10px #ffffff;
+}
+
+.leds {
+  text-align: center;
+}
+
+/* Page Layout */
+.content {
+  max-width: 700px;
+  align-self: center;
+  display: inline-block;
+  text-align: left;
+}
+
+.fullwidth {
+  width: 100%;
+}
+
+@media (min-width: 700px) {
+  .content {
+    min-width: 375px;
+  }
+
+  .centered {
+    text-align: center;
+  }
+}
+
+@media (max-width: 700px) {
+  .content {
+    width: 100%;
+  }
+}
+
+/* Main element groupings */
+
+.panel td {
+    text-align: center;
+    vertical-align: top;
+}
+
+.parameters tr td:first-child {
+    text-align: center;
+    vertical-align: top;
+    width:1%;
+}
+
+.chart tr th {
+  padding-right: 8px;
+}
+
+.chart tr td:first-child {
+  width:1%;
+}
+
+.bordered {
+  border: 1px solid;
+  border-collapse: collapse;
+  padding: 3px;
+}
+
+.led {
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+  border: 1px solid;
+  text-align: center;
+  display: inline-block;
+  margin: 10px;
+}
+
+.led-small {
+  height: 15px;
+  width: 15px;
+  border-radius: 50%;
+  margin: auto;
+}
+
+/* just big circles - braids, clouds */
+
+.bigknob {
+  height: 55px;
+  width: 55px;
+  border-radius: 50%;
+  border: 3px solid;
+  text-align: center;
+  display: inline-block;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.smallknob {
+  height: 40px;
+  width: 40px;
+  border-radius: 50%;
+  border: 3px solid;
+  text-align: center;
+  display: inline-block;
+  margin: 10px;
+}
+
+/* white knobs with wipers -rings, peaks */
+.knob {
+  margin: auto; /* this centers the block within it's container (usually a td) */
+  padding: 5px;
+  width: 50px;
+  height: 50px;
+  background-color: white;
+  border: 5px solid;
+  border-radius: 50%;
+}
+
+@media screen and (prefers-color-scheme: dark) {
+  .knob {
+    background-color: black;
+  }
+}
+
+.knob-ccw {
+  transform: translate(25px, 20px) rotate(140deg) translateX(15px);
+  transform-origin: left;
+}
+
+.knob-cw {
+  transform: translate(25px, 20px) rotate(40deg) translateX(15px);
+  transform-origin: left;
+}
+
+.knob-center {
+  transform: translate(25px, 20px) rotate(-90deg) translateX(15px);
+  transform-origin: left;
+}
+
+.knob-wiper {
+  width: 22px;
+  display: block;
+  height: 6px;
+  background-color: white;
+  color: green;
+}
+
+.att {
+  margin: auto; /* this centers the block within it's container (usually a td) */
+  width: 20px;
+  height: 20px;
+  background-color: black;
+  border-radius: 50%;
+}
+
+.att-center {
+  transform: translate(10px, 8px) rotate(-90deg) translateX(6px);
+  transform-origin: left;
+}
+
+.att-ccw {
+  transform: translate(10px, 8px) rotate(140deg) translateX(6px);
+  transform-origin: left;
+}
+
+.att-cw {
+  transform: translate(10px, 8px) rotate(40deg) translateX(6px);
+  transform-origin: left;
+}
+
+.steel {
+  background-color: #bbbbbb;
+  text-align: center;
+  max-width: 300px;
+}
+
+.att-wiper {
+  width: 5px;
+  display: block;
+  height: 3px;
+  background-color: white;
+  color: green;
+}
+
+.button-black {
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+  border: 1px solid;
+  text-align: center;
+  display: inline-block;
+  margin: 10px;
+  background-color: #999999;
+}
+
+.lcd {
+  width: 90%;
+  height: 90px;
+  border-radius: 5px;
+  border: 1px solid;
+  display: inline-block;
+  background-color: #eeeeee;
+}
+
+.slider {
+  margin: auto; 
+  margin-top: 10px;
+
+  width: 10px;
+  height: 100px;
+  border-radius: 2px;
+  background-color: black;
+  overflow: auto;
+}
+
+.slider-led {
+  width: 6px;
+  margin: 2px;
+  height: 10px;
+  border-radius: 0px;
+  background-color: white;
+  position: relative;
+}
+
+.jack {
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  border: 4px solid;
+  border-color: #888888;
+  text-align: center;
+  display: inline-block;
+  margin: 10px;
+  background-color: black;
+}
+
+/* Disting I/o labels and text params */
+
+.control {
+     background-color: #000000;
+     color: #ffffff;
+     padding: 10px;
+     margin: 3px;
+     display: inline-block;
+     border-radius: 4px;
+     font-size: large;
+}
+
+.parameter {
+     /*text-align: center; */
+     width: 25%;
+}
+
+/* iOS-like button */
+
+.button {
+  background-color: #007dd8;
+  border: none;
+  color: white;
+  padding: 10px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
+  margin: 4px 2px;
+  border-radius: 6px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+a.button:visited {
+  color:white;
+}</style><b>General</b><br /><a href="#info">Info</a><br />
+<b>Modes</b><br /><a href="#modes">Modes</a><br />
+<b>Specific Cards</b><br /><a href="#halls_of_valhalla">Halls of Valhalla</a><br /><h2>General</h2><a name="info"></a><h2>Info</h2>
+  <div class="centered">
+    <div class="content">
+      <h3>Pico DSP (Xodes Mod)</h3>
+      <p>Pico DSP is a small (3HP) digital effects module by Erica Synths. It is considered the little brother to the Erica Synths Black Hole module.</p>
+      <p>This mod allows the Pico DSP module to use effects cards from Tiptop's Z-DSP module.  When using this mod the parameters and the order of the effects on the card will change.  The mod can either be made as a backpack which sits underneath the Pico DSP module or as a sidecar which is accessible from the top.</p>
+      <p>The module has a mono audio input, and stereo outputs.</p>
+      <p>There is a button in the middle of the module that changes between the eight different effects, and an LED that displays the current effect.</p>
+      <h3>Links</h3>
+      <a class="button" href="https://www.ericasynths.lv/media/Pico_DSP_Manual.pdf">Pico DSP Manual</a><br>
+      <a class="button" href="https://www.xodes.net/product/bci-2hp-eurorack-zdsp-algorithm-card-adapter">Xodes BCI</a>
+    </div>
+  </div>
+<br /><br />
+<h2>Modes</h2><a name="modes"></a><h2>Modes</h2>
+  <div class="centered">
+    <div class="content">
+      <h3>Parameter Map</h3>
+      <table class="parameters">
+        <tr>
+          <th class="centered"></th>
+          <th class="centered">Pico Control</th>
+          <th class="centered">Algorithm Parameter</th>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-black"></div></td>
+          <td class="centered">Par1</td>
+          <td class="centered">Parameter 2</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-black"></div></td>
+          <td class="centered">Par2</td>
+          <td class="centered">Parameter 3</td>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-black"></div></td>
+          <td class="centered">Dry/Wet</td>
+          <td class="centered">Parameter 1</td>
+        </tr>
+      </table>
+      
+      <h3>Algorithm Ordering</h3>
+      <table class="parameters">
+        <tr>
+          <th class="centered">LED</th>
+          <th class="centered">Algorithm</th>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-black"></div></td>
+          <td class="centered">Algorithm #1</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-white"></div></td>
+          <td class="centered">Algorithm #8</td>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-yellow"></div></td>
+          <td class="centered">Algorithm #6</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-green"></div></td>
+          <td class="centered">Algorithm #2</td>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-light-blue"></div></td>
+          <td class="centered">Algorithm #4</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-dark-blue"></div></td>
+          <td class="centered">Algorithm #3</td>
+        </tr>
+        <tr class="highlighted-row">
+          <td><div class="led erica-pink"></div></td>
+          <td class="centered">Algorithm #7</td>
+        </tr>
+        <tr>
+          <td><div class="led erica-red"></div></td>
+          <td class="centered">Algorithm #5</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+<br /><br />
+<h2>Specific Cards</h2><a name="halls_of_valhalla"></a><h2>Halls of Valhalla</h2>
+  <div class="centered">
+	<div class="content">
+	  <table class="parameters">
+		<tr>
+		  <th class="centered">LED</th>
+		  <th class="centered">Effect</th>
+		  <th class="centered">Wet/Dry</th>
+		  <th class="centered">Par 1</th>
+		  <th class="centered">Par 2</th>
+		</tr>
+		<tr class="highlighted-row">
+		  <td><div class="led erica-black"></div></td>
+		  <td class="centered">1-Room</td>
+		  <td class="centered">Decay</td>
+		  <td class="centered">Tone</td>
+		  <td class="centered">Chorus</td>
+		</tr>
+		<tr>
+		  <td><div class="led erica-white"></div></td>
+		  <td class="centered">8-Ginnungagap</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Pitch</td>
+		</tr>
+		<tr class="highlighted-row">
+		  <td><div class="led erica-yellow"></div></td>
+		  <td class="centered">6-Nilfheim</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+		<tr>
+		  <td><div class="led erica-green"></div></td>
+		  <td class="centered">2-Chamber</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+		<tr class="highlighted-row">
+		  <td><div class="led erica-light-blue"></div></td>
+		  <td class="centered">4-EnsembleVerb</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+		<tr>
+		  <td><div class="led erica-dark-blue"></div></td>
+		  <td class="centered">3-Plate</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+		<tr class="highlighted-row">
+		  <td><div class="led erica-pink"></div></td>
+		  <td class="centered">7-Asgard</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Pitch</td>
+		</tr>
+		<tr>
+		  <td><div class="led erica-red"></div></td>
+		  <td class="centered">5-Cathedral</td>
+		  <td class="centered">Decay</td>
+			<td class="centered">Tone</td>
+			<td class="centered">Chorus</td>
+		</tr>
+	  </table>
+	  <h3>Notes</h3>
+	  <p>The algorithm order is different from the original order, numbers indicate the original order in increasing size of reverb space. Decay: the first half of the knob travel affects normal decays, beyond that are much larger spaces. Tone: dampens the reverb. Chorus: adds modulation and lushness™</p>
+	  <h3>Links</h3>
+<a class="button" href="https://www.ericasynths.lv/media/Pico_DSP_Manual.pdf">Pico DSP Manual</a><br>
+		<a class="button" href="https://www.xodes.net/product/bci-2hp-eurorack-zdsp-algorithm-card-adapter">Xodes BCI</a>
+	</div>
+  </div>
+<br /><br />


### PR DESCRIPTION
This is a clone of the Pico DSP cheat sheet that has been customized for the xodes mod that allows any tiptop x-dsp card to be used on the Pico DSP.  

Mainly it has the pattern and parameter reference maps but I also added details for the Halls of Valhalla card.  Additional cards could be added I just don't have any others.